### PR TITLE
add basic light/dark mode support (mui theming)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,6 @@ function App() {
             top: 0,
             left: 0,
             width: "calc(100vw-16px)",
-            backgroundColor: "white",
             zIndex: 99,
           }}
         >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,15 +2,24 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { BrowserRouter, Route, Routes } from "react-router";
+import { ThemeProvider, CssBaseline } from "@mui/material";
+import { getTheme } from "./theme";
 
-//eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+// Theme is set to 'light' by default to preserve current appearance
+// Change to 'dark' to test appearance under dark mode
+const theme = getTheme("dark");
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = ReactDOM.createRoot(document.getElementById("root")!);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <Routes>
-        <Route path="/jedi-on-tauntauns/" element={<App />}></Route>
-      </Routes>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Routes>
+          <Route path="/jedi-on-tauntauns/" element={<App />} />
+        </Routes>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { getTheme } from "./theme";
 
 // Theme is set to 'light' by default to preserve current appearance
 // Change to 'dark' to test appearance under dark mode
-const theme = getTheme("dark");
+const theme = getTheme("light");
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = ReactDOM.createRoot(document.getElementById("root")!);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,9 @@
+import { createTheme } from "@mui/material/styles";
+
+export function getTheme(mode: "light" | "dark") {
+  return createTheme({
+    palette: {
+      mode,
+    },
+  });
+}


### PR DESCRIPTION
Functionality exploration of dark themed application, toggled off by default in committed version. 
you can test dark mode by changing getTheme("light") to getTheme("dark") in index.tsx.


 * wrapped app in ThemeProvider and added CssBaseline
 * created getTheme(mode) helper for light/dark switching
 * left default mode as "light" to avoid visual changes
 * hardcoded background on <Tabs> was causing issues in dark mode — removed the line entirely since it worked fine without


screenshot included below — everything looks fine to me with cursory glance. Didn't sort out management of datastore, didn't delve into datastructure or react components much for modification. 

![image](https://github.com/user-attachments/assets/546ab2c8-23fc-465c-a36a-587ba6d623c0)
